### PR TITLE
set up users with access tokens, roles, uuids; sets up clients model …

### DIFF
--- a/api/app/Models/Client.php
+++ b/api/app/Models/Client.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\HasUuid;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Client Model
+ * 
+ * Represents a client in the system. A client can be associated with a user account
+ * but can also exist without one (for clients who haven't registered yet).
+ */
+class Client extends Model
+{
+    use HasFactory, HasUuid;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+        'name',
+        'email',
+        'phone',
+        'notes',
+    ];
+
+    /**
+     * Get the user associated with this client.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the conversations for this client.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function conversations()
+    {
+        return $this->hasMany(Conversation::class);
+    }
+
+    /**
+     * Get the appointments for this client.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function appointments()
+    {
+        return $this->hasMany(Appointment::class);
+    }
+}

--- a/api/app/Models/User.php
+++ b/api/app/Models/User.php
@@ -3,14 +3,22 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Traits\HasUuid;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
+/**
+ * User Model
+ * 
+ * Represents a user in the system with role-based access control.
+ * Users can be admins, artists, or clients.
+ */
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, HasUuid, Notifiable;
 
     /**
      * The attributes that are mass assignable.
@@ -21,6 +29,10 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
+        'phone',
+        'avatar',
+        'google_calendar_token',
     ];
 
     /**
@@ -31,6 +43,7 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'google_calendar_token',
     ];
 
     /**
@@ -43,6 +56,47 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'google_calendar_token' => 'json',
         ];
+    }
+
+    /**
+     * Check if the user is an admin.
+     *
+     * @return bool
+     */
+    public function isAdmin(): bool
+    {
+        return $this->role === 'admin';
+    }
+
+    /**
+     * Check if the user is an artist.
+     *
+     * @return bool
+     */
+    public function isArtist(): bool
+    {
+        return $this->role === 'artist';
+    }
+
+    /**
+     * Check if the user is a client.
+     *
+     * @return bool
+     */
+    public function isClient(): bool
+    {
+        return $this->role === 'client';
+    }
+
+    /**
+     * Get the client associated with this user.
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function client()
+    {
+        return $this->hasOne(Client::class);
     }
 }

--- a/api/database/factories/ClientFactory.php
+++ b/api/database/factories/ClientFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Client;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Client>
+ */
+class ClientFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'id' => Uuid::uuid4()->toString(),
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'phone' => fake()->phoneNumber(),
+            'notes' => fake()->paragraph(),
+        ];
+    }
+
+    /**
+     * Indicate that the client has a user account.
+     */
+    public function withUser(): static
+    {
+        return $this->state(function (array $attributes) {
+            $user = User::factory()->create([
+                'email' => $attributes['email'],
+                'name' => $attributes['name'],
+                'phone' => $attributes['phone'],
+                'role' => 'client',
+            ]);
+
+            return [
+                'user_id' => $user->id,
+            ];
+        });
+    }
+}

--- a/api/database/factories/UserFactory.php
+++ b/api/database/factories/UserFactory.php
@@ -2,9 +2,11 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
@@ -24,10 +26,13 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
+            'id' => Uuid::uuid4()->toString(),
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'role' => 'client',
+            'phone' => fake()->phoneNumber(),
             'remember_token' => Str::random(10),
         ];
     }
@@ -37,8 +42,28 @@ class UserFactory extends Factory
      */
     public function unverified(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn(array $attributes) => [
             'email_verified_at' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the user is an admin.
+     */
+    public function admin(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'role' => 'admin',
+        ]);
+    }
+
+    /**
+     * Indicate that the user is an artist.
+     */
+    public function artist(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'role' => 'artist',
         ]);
     }
 }

--- a/api/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/api/database/migrations/0001_01_01_000000_create_users_table.php
@@ -12,11 +12,15 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('id')->primary();
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->enum('role', ['admin', 'artist', 'client'])->default('client');
+            $table->string('phone')->nullable();
+            $table->string('avatar')->nullable();
+            $table->json('google_calendar_token')->nullable();
             $table->rememberToken();
             $table->timestamps();
         });
@@ -29,7 +33,7 @@ return new class extends Migration
 
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
-            $table->foreignId('user_id')->nullable()->index();
+            $table->foreignUuid('user_id')->nullable()->index();
             $table->string('ip_address', 45)->nullable();
             $table->text('user_agent')->nullable();
             $table->longText('payload');

--- a/api/database/migrations/2025_03_05_113648_modify_users_table_add_role_and_fields.php
+++ b/api/database/migrations/2025_03_05_113648_modify_users_table_add_role_and_fields.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // This migration is not needed as we've already included these fields
+        // in the initial users table migration.
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // No changes to reverse
+    }
+};

--- a/api/database/migrations/2025_03_05_113705_create_personal_access_tokens_table.php
+++ b/api/database/migrations/2025_03_05_113705_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuidMorphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/api/database/migrations/2025_03_05_113749_create_clients_table.php
+++ b/api/database/migrations/2025_03_05_113749_create_clients_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('clients', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('user_id')->nullable();
+            $table->string('name');
+            $table->string('email');
+            $table->string('phone')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('clients');
+    }
+};

--- a/api/database/seeders/DatabaseSeeder.php
+++ b/api/database/seeders/DatabaseSeeder.php
@@ -2,10 +2,14 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
+/**
+ * Database Seeder
+ * 
+ * Main seeder class that calls all other seeders.
+ */
 class DatabaseSeeder extends Seeder
 {
     /**
@@ -13,11 +17,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            UserSeeder::class,
         ]);
     }
 }

--- a/api/database/seeders/UserSeeder.php
+++ b/api/database/seeders/UserSeeder.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * User Seeder
+ * 
+ * Creates default users for development and testing.
+ */
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Create admin user
+        User::create([
+            'id' => Uuid::uuid4()->toString(),
+            'name' => 'Admin User',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('password'),
+            'role' => 'admin',
+            'email_verified_at' => now(),
+        ]);
+
+        // Create artist user
+        User::create([
+            'id' => Uuid::uuid4()->toString(),
+            'name' => 'Artist User',
+            'email' => 'artist@example.com',
+            'password' => Hash::make('password'),
+            'role' => 'artist',
+            'phone' => '555-123-4567',
+            'email_verified_at' => now(),
+        ]);
+
+        // Create client user
+        User::create([
+            'id' => Uuid::uuid4()->toString(),
+            'name' => 'Client User',
+            'email' => 'client@example.com',
+            'password' => Hash::make('password'),
+            'role' => 'client',
+            'phone' => '555-987-6543',
+            'email_verified_at' => now(),
+        ]);
+
+        // Create additional random users
+        User::factory()->count(5)->create();
+        User::factory()->artist()->count(3)->create();
+    }
+}


### PR DESCRIPTION
I've completed Step 3 of the implementation plan, which involved creating user and authentication migrations. Here's a summary of what I did:
Updated the users table migration to:
Use UUIDs instead of auto-incrementing IDs
Add role field with enum values (admin, artist, client)
Add additional fields like phone, avatar, and google_calendar_token
Update foreign key references to use UUIDs
Created the personal_access_tokens table migration for Sanctum with:
UUID primary key
UUID morphs for polymorphic relationships
Fields for token name, abilities, and expiration
Created the clients table migration with:
UUID primary key
Foreign key relationship to users table
Fields for client information (name, email, phone, notes)
Updated the User model to:
Use the HasUuid trait for UUID generation
Add Sanctum support with HasApiTokens trait
Include role-related methods (isAdmin, isArtist, isClient)
Define relationship to Client model
Created the Client model with:
HasUuid trait for UUID generation
Relationship to User model
Placeholder relationships for conversations and appointments
Updated the UserFactory to:
Generate UUIDs for new users
Support different roles (admin, artist, client)
Include additional fields like phone
Created the ClientFactory to:
Generate UUIDs for new clients
Support creating clients with or without user accounts
Created seeders for:
Default admin, artist, and client users
Random users for testing